### PR TITLE
Added ipc flag to docker-compose to allow ROS2 communication

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     stdin_open: true
     tty: true
     network_mode: host
+    ipc: host
     privileged: false
     user: ${CURRENT_UID}  # CURRENT_UID=$(id -u):$(id -g)
     volumes:


### PR DESCRIPTION
Changes per commit message to enable ROS2 communication with other containers/host